### PR TITLE
Route uploads to n8n webhook

### DIFF
--- a/static/html/rfq_distribution_static.html
+++ b/static/html/rfq_distribution_static.html
@@ -133,17 +133,21 @@ document.addEventListener("DOMContentLoaded", function() {
             loading.style.display = 'block';
 
             var xhr = new XMLHttpRequest();
-            xhr.open('POST', '/rfqd', true);
+            // Send the RFQ files to the n8n workflow instead of the Flask route
+            xhr.open('POST', 'https://<n8n-host>/webhook/rfq', true);
 
             xhr.onreadystatechange = function() {
                 if (xhr.readyState === XMLHttpRequest.DONE) {
                     if (xhr.status === 200) {
                         var response = JSON.parse(xhr.responseText);
-                        var tempDiv = document.createElement('div');
-                        tempDiv.innerHTML = response.result_html;
-                        var newContent = tempDiv.querySelector('#content-container').innerHTML;
-                        var contentContainer = document.getElementById('content-container');
-                        contentContainer.innerHTML = newContent;
+                        var resultHtml = response.result_html || response.html || response.data;
+                        if (resultHtml) {
+                            var tempDiv = document.createElement('div');
+                            tempDiv.innerHTML = resultHtml;
+                            var newContent = tempDiv.querySelector('#content-container').innerHTML;
+                            var contentContainer = document.getElementById('content-container');
+                            contentContainer.innerHTML = newContent;
+                        }
                         if (loading) loading.style.display = 'none';
                     } else {
                         alert('An error occurred during the request.');


### PR DESCRIPTION
## Summary
- send RFQ files to an n8n webhook instead of the original Flask endpoint
- allow more flexible handling of n8n JSON responses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cd23c54548329aa48ece07b7a1b99